### PR TITLE
updating PiGPIO.jl docs & examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ in the terminal.
 
 ```julia
 using Pkg
-Pkg.add("https://github.com/JuliaBerry/PiGPIO.jl")
+Pkg.add("PiGPIO")
 
 using PiGPIO
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ set_mode(p::Pi, pin::Int, mode)
 get_mode(p::Pi, pin::Int)
 # mode can be INPUT or OUTPUT
 
-read(p, pin)
-write(p, pin, state)
+PiGPIO.read(p, pin)
+PiGPIO.write(p, pin, state)
 #state can be HIGH, LOW, ON, OFF
 
-set_PWM_dutycycle(p, pin, dutycyle)
+PiGPIO.set_PWM_dutycycle(p, pin, dutycyle)
 #dutycyle defaults to a range 0-255
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ work is done by the daemon. One benefit of working this way is that you can
 remotely access the pi over a network and multiple instances can be connected
 to the daemon simultaneously.
 
+## Launching the Daemon
+
 Launching the daemon requires sudo privileges. Launch by typing `sudo pigpiod`
 in the terminal.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PiGPIO
+# PiGPIO.jl
 
 #### Control GPIO pins on the Raspberry Pi from Julia
 
@@ -49,7 +49,7 @@ using PiGPIO
 pi=Pi() #connect to pigpiod daemon on localhost
 ```
 
-## Reference
+## Example Usage
 
 ```julia
 set_mode(p::Pi, pin::Int, mode)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,7 +2,12 @@
 
 Documentation for PiGPIO.jl
 
-### Control GPIO pins on the Raspberry Pi from Julia
+#### Control GPIO pins on the Raspberry Pi from Julia
+
+[![][docs-stable-img]][docs-stable-url]
+
+[docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
+[docs-stable-url]: https://pkg.julialang.org/docs/PiGPIO/
 
 [![PiGPIO](https://img.youtube.com/vi/UmSQjkaATk8/0.jpg)](https://www.youtube.com/watch?v=UmSQjkaATk8)
 
@@ -13,7 +18,7 @@ input outputs (GPIO).
 This package is an effective translation of the python package for the same.
 Which can be found [here](http://abyz.me.uk/rpi/pigpio/python.html)
 
-## Features
+### Features
 
 * OS independent. Only Julia 1.0+ required.
 * Controls one or more Pi's.
@@ -30,6 +35,8 @@ work is done by the daemon. One benefit of working this way is that you can
 remotely access the pi over a network and multiple instances can be connected
 to the daemon simultaneously.
 
+## Launching the Daemon
+
 Launching the daemon requires sudo privileges. Launch by typing `sudo pigpiod`
 in the terminal.
 
@@ -37,7 +44,7 @@ in the terminal.
 
 ```julia
 using Pkg
-Pkg.add("https://github.com/JuliaBerry/PiGPIO.jl")
+Pkg.add("PiGPIO")
 
 using PiGPIO
 
@@ -51,10 +58,11 @@ set_mode(p::Pi, pin::Int, mode)
 get_mode(p::Pi, pin::Int)
 # mode can be INPUT or OUTPUT
 
-read(p, pin)
-write(p, pin, state)
+PiGPIO.read(p, pin)
+PiGPIO.write(p, pin, state)
 #state can be HIGH, LOW, ON, OFF
 
-set_PWM_dutycycle(p, pin, dutycyle)
+PiGPIO.set_PWM_dutycycle(p, pin, dutycyle)
 #dutycyle defaults to a range 0-255
 ```
+

--- a/examples/01_blink.jl
+++ b/examples/01_blink.jl
@@ -1,18 +1,19 @@
 
 using PiGPIO
 
-red_pin = 18
+red_pin = 18 #change this accordingly with your GPIO pin number
 p=Pi()
-set_mode(p, red_pin, OUTPUT)
+set_mode(p, red_pin, PiGPIO.OUTPUT)
 try 
-	for i in 1:10
-		write(p, red_pin, HIGH)
-		sleep(0.5)
-		write(p, red_pin, LOW)
-		sleep(0.5)
-	end
+    for i in 1:10
+        PiGPIO.write(p, red_pin, PiGPIO.HIGH)
+        sleep(0.5)
+        PiGPIO.write(p, red_pin, PiGPIO.LOW)
+        sleep(0.5)
+    end
 finally
-	println("Cleaning up!")
-	set_mode(p, red_pin, INPUT)
+    println("Cleaning up!")
+    set_mode(p, red_pin, PiGPIO.INPUT)
 end
+
 	

--- a/examples/02_blink_twice.jl
+++ b/examples/02_blink_twice.jl
@@ -1,23 +1,25 @@
 
 using PiGPIO
 
-red_pin1 = 18
+red_pin1 = 18 #change these numbers accordingly with your GPIO pins
 red_pin2 = 23
 
-pinMode(red_pin1, OUTPUT)
-pinMode(red_pin2, OUTPUT)
+p=Pi()
+
+set_mode(p, red_pin1, PiGPIO.OUTPUT)
+set_mode(p, red_pin2, PiGPIO.OUTPUT)
 
 try 
-	for i in 1:10
-		digitalWrite(red_pin1, HIGH)
-        digitalWrite(red_pin2, LOW)
-		sleep(0.5)
-        digitalWrite(red_pin1, LOW)
-		digitalWrite(red_pin2, HIGH)
-		sleep(0.5)
-	end
+    for i in 1:10
+        PiGPIO.write(p, red_pin1, PiGPIO.HIGH)
+        PiGPIO.write(p, red_pin2, PiGPIO.LOW)
+        sleep(0.5)
+        PiGPIO.write(p, red_pin1, PiGPIO.LOW)
+        PiGPIO.write(p, red_pin2, PiGPIO.HIGH)
+        sleep(0.5)
+    end
 finally
     println("Cleaning up!")
-	pinMode(red_pin1, INPUT)
-    pinMode(red_pin2, INPUT)
+    set_mode(p, red_pin1, PiGPIO.INPUT)
+    set_mode(p, red_pin2, PiGPIO.INPUT)
 end


### PR DESCRIPTION
Here, I was using the old docs to explore the package when I realised that the examples were all outdated. So, I grabbed a raspberry pi, 4 jumper cables, 2 LEDs, and a breadboard to create 2 circuits. I found out the new functions using the methods() functions as some of them required me to add `PiGPIO.` in front of them. Also it was seen that the `README.md` didn't eactly correspond with the function names from example 2 so I knew that that had to be changed as well. I knew it was tested correctly when I got both examples 1 and 2 to run on my circuit without any errors, and it was clear that the LEDs were blinking. In example 1, one LED was blinking on and off, and in example 2, two LEDS were blinking on and off alternatively like sirens.