### PR TITLE
Fix to rxbuf reader

### DIFF
--- a/src/pi.jl
+++ b/src/pi.jl
@@ -351,7 +351,7 @@ end
 
 """Returns count bytes from the command socket."""
 function rxbuf(self::Pi, count)
-    ext = readbytes(self.sl.s, count, all)
+    ext = Base.read(self.sl.s, count)
     return ext
 end
 


### PR DESCRIPTION
Per #19 and the suggestion from @Alexander-Barth, I was able to make this fix to PiGPIO.jl! It works like it does in the python implementation now. I did have to do one more fix which was to explicitly pass in `Base.read`. Otherwise, this was what Alexander had suggested. :) 

Thanks! 